### PR TITLE
Exposed APIs related to verify server certicates to JNI

### DIFF
--- a/coreapi/linphonecore_jni.cc
+++ b/coreapi/linphonecore_jni.cc
@@ -6870,3 +6870,12 @@ JNIEXPORT void JNICALL Java_org_linphone_core_LinphoneCoreImpl_setUserCertificat
 	if (path) env->ReleaseStringUTFChars(jpath, path);
 }
 
+
+JNIEXPORT void JNICALL Java_org_linphone_core_LinphoneCoreImpl_verifyServerCertificates(JNIEnv *env, jobject thiz, jlong lc, jboolean yesno) {
+	linphone_core_verify_server_certificates((LinphoneCore *)lc, yesno);
+}
+
+JNIEXPORT void JNICALL Java_org_linphone_core_LinphoneCoreImpl_verifyServerCn(JNIEnv *env, jobject thiz, jlong lc, jboolean yesno) {
+	linphone_core_verify_server_cn((LinphoneCore *)lc, yesno);
+}
+

--- a/java/common/org/linphone/core/LinphoneCore.java
+++ b/java/common/org/linphone/core/LinphoneCore.java
@@ -2284,4 +2284,8 @@ public interface LinphoneCore {
 	 * Set user certificates directory path (used by SRTP-DTLS).
 	 */
 	public void setUserCertificatesPath(String path);
+
+	public void verifyServerCn(boolean yesno);
+
+	public void verifyServerCertificates(boolean yesno);
 }

--- a/java/impl/org/linphone/core/LinphoneCoreImpl.java
+++ b/java/impl/org/linphone/core/LinphoneCoreImpl.java
@@ -1636,4 +1636,16 @@ class LinphoneCoreImpl implements LinphoneCore {
 	public void setUserCertificatesPath(String path) {
 		setUserCertificatesPath(nativePtr, path);
 	}
+
+	private native void verifyServerCertificates(long nativePtr, boolean yesno);
+	@Override
+	public void verifyServerCertificates(boolean yesno) {
+		verifyServerCertificates(nativePtr, yesno);
+	}
+
+	private native void verifyServerCn(long nativePtr, boolean yesno);
+	@Override
+	public void verifyServerCn(boolean yesno) {
+		verifyServerCn(nativePtr, yesno);
+	}
 }


### PR DESCRIPTION
Added two Linphone's APIs related to verify server certificate to JNI, so that Android can bypass the verification of the server certificate when establishing the TLS connection.

This is useful for testing Linphone using TLS on development server.