### PR TITLE
linphonec will only prompt for auth once per session

### DIFF
--- a/console/linphonec.c
+++ b/console/linphonec.c
@@ -900,6 +900,9 @@ linphonec_prompt_for_auth_final(LinphoneCore *lc)
 	rl_line_buffer[0]='\0';
 	rl_event_hook=old_event_hook;
 #endif
+
+	reentrancy--;
+
 	return 1;
 }
 


### PR DESCRIPTION
After commit [1], linphonec will only prompt for auth info once per session. Fix this by resetting the "reentrancy" flag when linphonec_prompt_for_auth_final completes.

 [1]: https://github.com/BelledonneCommunications/linphone/commit/6cf6ce675dd84b10e019759bfe2b181513e95f7d