### PR TITLE
activate ZRTP out of the box

### DIFF
--- a/coreapi/linphonecore.c
+++ b/coreapi/linphonecore.c
@@ -6675,7 +6675,7 @@ bool_t linphone_core_media_encryption_supported(const LinphoneCore *lc, Linphone
 }
 
 LinphoneStatus linphone_core_set_media_encryption(LinphoneCore *lc, LinphoneMediaEncryption menc) {
-	const char *type="none";
+	const char *type="zrtp";
 	int ret=-1;
 
 	switch(menc){
@@ -6722,15 +6722,15 @@ LinphoneMediaEncryption linphone_core_get_media_encryption(LinphoneCore *lc) {
 	const char* menc = lp_config_get_string(lc->config, "sip", "media_encryption", NULL);
 
 	if (menc == NULL)
-		return LinphoneMediaEncryptionNone;
+		return LinphoneMediaEncryptionZRTP;
 	else if (strcmp(menc, "srtp")==0)
 		return LinphoneMediaEncryptionSRTP;
 	else if (strcmp(menc, "dtls")==0)
 		return LinphoneMediaEncryptionDTLS;
-	else if (strcmp(menc, "zrtp")==0)
-		return LinphoneMediaEncryptionZRTP;
-	else
+	else if (strcmp(menc, "none")==0)
 		return LinphoneMediaEncryptionNone;
+	else
+		return LinphoneMediaEncryptionZRTP;
 }
 
 bool_t linphone_core_is_media_encryption_mandatory(LinphoneCore *lc) {

--- a/gtk/propertybox.c
+++ b/gtk/propertybox.c
@@ -1304,13 +1304,13 @@ static void linphone_gtk_media_encryption_changed(GtkWidget *combo){
 		}else if (strcasecmp(selected,"DTLS")==0){
 			linphone_core_set_media_encryption(lc,LinphoneMediaEncryptionDTLS);
 			gtk_widget_set_sensitive(mandatory_box,TRUE);
-		}else if (strcasecmp(selected,"ZRTP")==0){
-			linphone_core_set_media_encryption(lc,LinphoneMediaEncryptionZRTP);
-			gtk_widget_set_sensitive(mandatory_box,TRUE);
-		} else {
+		}else if (strcasecmp(selected,"None")==0){
 			linphone_core_set_media_encryption(lc,LinphoneMediaEncryptionNone);
 			gtk_widget_set_sensitive(mandatory_box,FALSE);
 			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(mandatory_box), FALSE);
+		} else {
+			linphone_core_set_media_encryption(lc,LinphoneMediaEncryptionZRTP);
+			gtk_widget_set_sensitive(mandatory_box,TRUE);
 		}
 		g_free(selected);
 	}else g_warning("gtk_combo_box_get_active_text() returned NULL");


### PR DESCRIPTION
If you care about the users' privacy, defaulting to ZRTP out of the box (with no configuration) seems like a good idea to me.

So users won't have to go to the preferences section and activate it manually.