### PR TITLE
CMake minimum required 3.0 -> 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 project(linphone VERSION 3.12.0 LANGUAGES C CXX)
 
 


### PR DESCRIPTION
# minimum required 3.0 is a bit contradiction to my experience. it should be 3.1 
# because CMake 3.1 introduced the CMAKE_CXX_STANDARD. Cmake 3.1 compiles fine,
# but CMake 3.0 does not have the CMAKE_CXX_STANDARD and then it does not use cxx11
# then you hit error: 
# expected template-name before ‘<’ token error enabled_shared_from_this