### PR TITLE
fix bug, linphone_core_accept_call will be crash when call is NULL, use by linphonec

### DIFF
--- a/coreapi/linphonecore.c
+++ b/coreapi/linphonecore.c
@@ -3731,7 +3731,7 @@ static LinphoneCall * get_unique_call(LinphoneCore *lc) {
 }
 
 LinphoneStatus linphone_core_accept_call(LinphoneCore *lc, LinphoneCall *call) {
-	return linphone_call_accept_with_params(call, NULL);
+	return linphone_core_accept_call_with_params(lc, call, NULL);
 }
 
 LinphoneStatus linphone_core_accept_call_with_params(LinphoneCore *lc, LinphoneCall *call, const LinphoneCallParams *params) {


### PR DESCRIPTION
Hi, Nearly i meet a issue, that when i use linphonec command to answer a call, it will crash. And I found it cause by linphone_core_accept_call(lc, NULL), see code bellow.

-------console/commands.c------
static int
lpc_cmd_answer(LinphoneCore *lc, char *args){
...
		if ( -1 == linphone_core_accept_call(lc, NULL) )
		{
			linphonec_out("Fail to accept incoming call\n");
		}
...
----------------------------------

so I fix linphone_core_accept_call like this:

 LinphoneStatus linphone_core_accept_call(LinphoneCore *lc, LinphoneCall *call) {
       return linphone_core_accept_call_with_params(lc, call, NULL);
 }

