### PR TITLE
update version in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([linphone],[3.11.2],[linphone-developers@nongnu.org])
+AC_INIT([linphone],[3.12.0],[linphone-developers@nongnu.org])
 AC_CANONICAL_SYSTEM
 AC_CONFIG_SRCDIR([coreapi/linphonecore.c])
 


### PR DESCRIPTION
Somehow the version string in configure.ac wasn't updated when version 3.12.0 was released. This patch updates configure.ac accordingly.