### PR TITLE
Re-add domain/proxy code to fix linphone_account_creator_create_proxy_config

### DIFF
--- a/coreapi/account_creator.c
+++ b/coreapi/account_creator.c
@@ -78,6 +78,12 @@ static char* _get_identity(const LinphoneAccountCreator *creator) {
 		LinphoneProxyConfig* proxy = linphone_core_create_proxy_config(creator->core);
 		LinphoneAddress* addr;
 
+		if (creator->domain) {
+			char * tmpidentity = ms_strdup_printf("sip:username@%s", creator->domain);
+			linphone_proxy_config_set_identity(proxy, tmpidentity);
+			ms_free(tmpidentity);
+		}
+
 		addr = linphone_proxy_config_normalize_sip_uri(proxy, creator->username ? creator->username : creator->phone_number);
 		if (addr == NULL) goto end;
 
@@ -108,6 +114,9 @@ LinphoneProxyConfig * linphone_account_creator_create_proxy_config(const Linphon
 		snprintf(buff, sizeof(buff), "%d", dial_prefix_number);
 		linphone_proxy_config_set_dial_prefix(cfg, buff);
 	}
+
+	if (linphone_proxy_config_get_server_addr(cfg) == NULL && creator->domain)
+		linphone_proxy_config_set_server_addr(cfg, creator->domain);
 
 	linphone_proxy_config_enable_register(cfg, TRUE);
 


### PR DESCRIPTION
We are using linphone_account_creator_create_proxy_config as follows:
```linphone_account_creator_set_username(account_creator, username);
linphone_account_creator_set_password(account_creator, password);
linphone_account_creator_set_domain(account_creator, domain);
linphone_account_creator_set_display_name(account_creator, display_name);
linphone_account_creator_set_transport(account_creator, linphone_transport_parse(transport));

LinphoneProxyConfig* proxyCfg = linphone_account_creator_configure(account_creator);
```
However, since commit b41b920426e2d4ab2dbc6aa6e5ac6423023ca1e7, linphone_proxy_config_check will fail because proxyCfg's reg_proxy parameter is NULL. Also _get_identity is unable to produce a valid identity.

I believe this also resolves the issue: https://github.com/BelledonneCommunications/linphone-iphone/issues/247