### PR TITLE
Modifications in the C# wrapper template (.mustache) file

### DIFF
--- a/wrappers/csharp/wrapper_impl.mustache
+++ b/wrappers/csharp/wrapper_impl.mustache
@@ -42,8 +42,8 @@ namespace Linphone
         public const string BELLE_SIP_LIB_NAME = "bellesip";
 				public const string BCTOOLBOX_LIB_NAME = "bctoolbox";
 #else
-        public const string BELLE_SIP_LIB_NAME = "linphone";
-				public const string BCTOOLBOX_LIB_NAME = "linphone";
+        public const string BELLE_SIP_LIB_NAME = LIB_NAME;
+				public const string BCTOOLBOX_LIB_NAME = LIB_NAME;
 #endif
 
 #if ANDROID

--- a/wrappers/csharp/wrapper_impl.mustache
+++ b/wrappers/csharp/wrapper_impl.mustache
@@ -99,10 +99,14 @@ namespace Linphone
 
 		internal GCHandle handle;
 		
-		~LinphoneObject() => Destructor(nativePtr, (IntPtr)handle);
+		~LinphoneObject()
+		{
+			linphone_object_data_destroy(nativePtr);
+			if (nativePtr != IntPtr.Zero) handle.Free();
+		}
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		private delegate void OnLinphoneObjectDataDestroyed(IntPtr data, IntPtr handlePtr);
+		private delegate void OnLinphoneObjectDataDestroyed(IntPtr data);
 
 		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 #if WINDOWS_UWP
@@ -139,12 +143,11 @@ namespace Linphone
 		[MonoPInvokeCallback(typeof(OnLinphoneObjectDataDestroyed))]
 #endif
 
-		private static void Destructor(IntPtr nativePtr, IntPtr handlePtr)
+		private static void linphone_object_data_destroy(IntPtr nativePtr)
 		{
 			if (nativePtr != IntPtr.Zero) {
 				belle_sip_object_data_remove(nativePtr, "cs_obj");
 				belle_sip_object_unref(nativePtr);
-				((GCHandle)handlePtr).Free();
 			}
 		}
 

--- a/wrappers/csharp/wrapper_impl.mustache
+++ b/wrappers/csharp/wrapper_impl.mustache
@@ -47,11 +47,11 @@ namespace Linphone
 #endif
 
 #if ANDROID
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void setAndroidLogHandler();
 #endif
 #if __IOS__
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void linphone_iphone_enable_logs();
 #endif
 
@@ -102,35 +102,35 @@ namespace Linphone
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		private delegate void OnLinphoneObjectDataDestroyed(IntPtr data);
 
-		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 #if WINDOWS_UWP
 		static extern int belle_sip_object_data_set(IntPtr ptr, string name, IntPtr data, IntPtr cb);
 #else
 		static extern int belle_sip_object_data_set(IntPtr ptr, string name, IntPtr data, OnLinphoneObjectDataDestroyed cb);
 #endif
 
-		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr belle_sip_object_data_get(IntPtr ptr, string name);
 
-		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr belle_sip_object_ref(IntPtr ptr);
 
-		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void belle_sip_object_unref(IntPtr ptr);
 
-		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void belle_sip_object_data_remove(IntPtr ptr, string data);
 
-		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr bctbx_list_next(IntPtr ptr);
 
-		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr bctbx_list_get_data(IntPtr ptr);
 
-		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr bctbx_list_append(IntPtr elem, string data);
 
-		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME)]
+		[DllImport(LinphoneWrapper.BCTOOLBOX_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr bctbx_list_append(IntPtr elem, IntPtr data);
 
 #if __IOS__
@@ -255,10 +255,10 @@ namespace Linphone
 	/// </summary>
 	public class LinphoneAndroid
 	{
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void ms_set_jvm_from_env(IntPtr jnienv);
 
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void setMediastreamerAndroidContext(IntPtr jnienv, IntPtr context);
 
 		/// <summary>
@@ -305,7 +305,7 @@ namespace Linphone
 	public class {{interfaceName}} : LinphoneObject
 	{
 		{{#methods}}
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		{{#cb_setter}}
 #if WINDOWS_UWP
 		static extern void {{name}}(IntPtr thiz, IntPtr cb);
@@ -371,7 +371,7 @@ namespace Linphone
 	public class {{className}} : LinphoneObject
 	{
 		{{#isLinphoneFactory}}
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr linphone_factory_create_core_cbs(IntPtr factory);
 
 		public CoreListener CreateCoreListener()
@@ -424,10 +424,10 @@ namespace Linphone
 		}
 		{{/isLinphoneCore}}
 		{{#dllImports}}
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		{{{prototype}}}
 		{{#has_second_prototype}}
-		[DllImport(LinphoneWrapper.LIB_NAME)]
+		[DllImport(LinphoneWrapper.LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 		{{second_prototype}}
 		{{/has_second_prototype}}
 

--- a/wrappers/csharp/wrapper_impl.mustache
+++ b/wrappers/csharp/wrapper_impl.mustache
@@ -98,9 +98,11 @@ namespace Linphone
 		internal IntPtr nativePtr;
 
 		internal GCHandle handle;
+		
+		~LinphoneObject() => Destructor(nativePtr, (IntPtr)handle);
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		private delegate void OnLinphoneObjectDataDestroyed(IntPtr data);
+		private delegate void OnLinphoneObjectDataDestroyed(IntPtr data, IntPtr handlePtr);
 
 		[DllImport(LinphoneWrapper.BELLE_SIP_LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
 #if WINDOWS_UWP
@@ -137,14 +139,12 @@ namespace Linphone
 		[MonoPInvokeCallback(typeof(OnLinphoneObjectDataDestroyed))]
 #endif
 
-		~LinphoneObject()
+		private static void Destructor(IntPtr nativePtr, IntPtr handlePtr)
 		{
-			//Console.WriteLine("Destroying " + this.ToString());
 			if (nativePtr != IntPtr.Zero) {
-				//Console.WriteLine("Unreffing " + this.ToString());
 				belle_sip_object_data_remove(nativePtr, "cs_obj");
 				belle_sip_object_unref(nativePtr);
-				handle.Free();
+				((GCHandle)handlePtr).Free();
 			}
 		}
 


### PR DESCRIPTION
As recently reported in the *linphone-xamarin* forum, there are some showstopping issues concerning iOS, together with a request to also enable the C# wrapper for .NET Framework projects. 

For more details, see issues [#8](https://github.com/BelledonneCommunications/linphone-xamarin/issues/8), [#9](https://github.com/BelledonneCommunications/linphone-xamarin/issues/9) and [#11](https://github.com/BelledonneCommunications/linphone-xamarin/issues/11) in the *linphone-xamarin* repository.

This pull request is intended to resolve these issues. There is one commit per issue (except the merge commit in the end).

Looking forward to constructive comments and eventually a pull :-)