### PR TITLE
Fix dtmf in daemon and align with linphone-desktop

### DIFF
--- a/daemon/commands/dtmf.cc
+++ b/daemon/commands/dtmf.cc
@@ -44,8 +44,8 @@ void DtmfCommand::exec(Daemon *app, const string& args) {
 	digit = digit_str.at(0);
 	if (isdigit(digit) || (digit == 'A') || (digit == 'B') || (digit == 'C') || (digit == 'D') || (digit == '*') || (digit == '#')) {
 		LinphoneCall *call = linphone_core_get_current_call(app->getCore());
-		linphone_core_play_dtmf(app->getCore(), digit, 100);
-		if (call == NULL) {
+		linphone_core_play_dtmf(app->getCore(), digit, 200);
+		if (call != NULL) {
 			linphone_call_send_dtmf(call, digit);
 		}
 		app->sendResponse(Response());


### PR DESCRIPTION
BUGFIX: Actually generate DTMF RTP messages. Without out this change
RFC 2833 RTP messages for DTMF tones do not get sent.

This bug was introduced with an update to use a newer dtmf api [1]
(where it moved from core to call), but the check for an active call was
actually ensuring that dtmf could only be sent if there were no active calls.
When there were no active calls, the daemon displayed this error::

  ortp-error-No dtmf generator at this time !

I verified that this fix (the change from `call == null` to `call != null`)
works as expected by running this and inspecting a call with wireshark
to make sure the RTP packets are actually sent.

Also, in comparing the dtmf logic in deamon and desktop, the dtmf tone
plays out for longer in desktop (200 vs 100), so use that in the daemon[2][3].
This only affects the audible playout and does not affect the bugfix.
If there is any hesitation to merge this because of the change to 200,
I'll revert the change to 200 and keep the bugfix described above.

[1] https://github.com/BelledonneCommunications/linphone/commit/af2ecd8cb67845e904d803d008ced2703e45423e
[2] https://github.com/BelledonneCommunications/linphone-desktop/blob/a3dc41ec5582276d4ee93b7c4cf193842c03dc7b/src/components/call/CallModel.cpp#L581-L586
[3] https://github.com/BelledonneCommunications/linphone-desktop/commit/af98291fac4be80cbd6a9a61987403d112b9cb57