### PR TITLE
Sort input file list

### DIFF
--- a/tools/genapixml.py
+++ b/tools/genapixml.py
@@ -641,7 +641,7 @@ class Project:
 		self.__discoverClasses()
 
 	def initFromDir(self, xmldir):
-		files = [ os.path.join(xmldir, f) for f in os.listdir(xmldir) if (os.path.isfile(os.path.join(xmldir, f)) and f.endswith('.xml')) ]
+		files = [ os.path.join(xmldir, f) for f in sorted(os.listdir(xmldir)) if (os.path.isfile(os.path.join(xmldir, f)) and f.endswith('.xml')) ]
 		self.initFromFiles(files)
 
 	def check(self):


### PR DESCRIPTION
Sort input file list
so that `liblinphone++.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

---
While working on the reproducible builds effort, I found that
when building the linphone package for openSUSE Linux (in disposable VMs),
there were differences between each build,
because ordering of functions in linphone++.cc
depended on the indeterministic filesystem order.